### PR TITLE
accession number verification

### DIFF
--- a/app/controllers/lab/orders_controller.rb
+++ b/app/controllers/lab/orders_controller.rb
@@ -29,9 +29,8 @@ module Lab
     end
 
     def verify_tracking_number
-      tracking_number = params.require(:tracking_number)
-      result = OrdersService.nlims_accession_number_exists?(tracking_number) || OrdersService.accession_number_exists?(tracking_number)
-      render json: { exists: result }, status: :ok
+      tracking_number = params.require(:accession_number)
+      render json: { exists: OrdersService.check_tracking_number(tracking_number) }, status: :ok
     end
 
     def destroy

--- a/app/controllers/lab/orders_controller.rb
+++ b/app/controllers/lab/orders_controller.rb
@@ -28,6 +28,12 @@ module Lab
       render json: OrdersSearchService.find_orders(filters)
     end
 
+    def verify_tracking_number
+      tracking_number = params.require(:tracking_number)
+      result = OrdersService.nlims_accession_number_exists?(tracking_number) || OrdersService.accession_number_exists?(tracking_number)
+      render json: { exists: result }, status: :ok
+    end
+
     def destroy
       OrdersService.void_order(params[:id], params[:reason])
       Lab::VoidOrderJob.perform_later(params[:id])

--- a/app/services/lab/lims/api/rest_api.rb
+++ b/app/services/lab/lims/api/rest_api.rb
@@ -87,6 +87,10 @@ class Lab::Lims::Api::RestApi
     end
   end
 
+  def verify_tracking_number(tracking_number)
+    find_lims_order(tracking_number)
+  end
+
   private
 
   attr_reader :config

--- a/app/services/lab/lims/api/rest_api.rb
+++ b/app/services/lab/lims/api/rest_api.rb
@@ -89,6 +89,9 @@ class Lab::Lims::Api::RestApi
 
   def verify_tracking_number(tracking_number)
     find_lims_order(tracking_number)
+  rescue InvalidParameters => e
+    Rails.logger.error("Failed to verify tracking number #{tracking_number}: #{e.message}")
+    false
   end
 
   private

--- a/app/services/lab/orders_service.rb
+++ b/app/services/lab/orders_service.rb
@@ -52,6 +52,10 @@ module Lab
       def order_test(order_params)
         Order.transaction do
           encounter = find_encounter(order_params)
+          if order_params[:accession_number].present? && check_tracking_number(order_params[:accession_number])
+            raise 'Accession number already exists'
+          end
+
           order = create_order(encounter, order_params)
 
           Lab::TestsService.create_tests(order, order_params[:date], order_params[:tests])

--- a/app/services/lab/orders_service.rb
+++ b/app/services/lab/orders_service.rb
@@ -141,6 +141,19 @@ module Lab
         )
       end
 
+      def accession_number_exists?(accession_number)
+        Lab::LabOrder.where(accession_number: accession_number).exists?
+      end
+
+      def nlims_accession_number_exists?(accession_number)
+        config = YAML.load_file('config/application.yml')
+        return false unless config['lims_api']
+
+        # fetch from the rest api and check if it exists
+        lims_api = Lab::Lims::ApiFactory.create_api
+        lims_api.verify_tracking_number(accession_number).present?
+      end
+
       ##
       # Attach the requesting clinician to an order
       def add_requesting_clinician(order, params)

--- a/app/services/lab/orders_service.rb
+++ b/app/services/lab/orders_service.rb
@@ -104,6 +104,10 @@ module Lab
         voided
       end
 
+      def check_tracking_number(tracking_number)
+        accession_number_exists?(tracking_number) || nlims_accession_number_exists?(tracking_number)
+      end
+
       private
 
       ##

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Lab::Engine.routes.draw do
   end
 
   get 'api/v1/lab/labels/order', to: 'labels#print_order_label'
-  get 'api/v1/lab/orders/accession_number', to: 'orders#verify_tracking_number'
+  get 'api/v1/lab/accession_number', to: 'orders#verify_tracking_number'
 
   # Metadata
   # TODO: Move the following to namespace /concepts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Lab::Engine.routes.draw do
   end
 
   get 'api/v1/lab/labels/order', to: 'labels#print_order_label'
+  get 'api/v1/lab/orders/accession_number', to: 'orders#verify_tracking_number'
 
   # Metadata
   # TODO: Move the following to namespace /concepts

--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -341,4 +341,30 @@ describe 'orders' do
       end
     end
   end
+
+  path '/api/v1/lab/accession_number' do
+    get 'Verify accession number' do
+      tags 'Orders'
+      description 'Verify if an accession number is valid and exists'
+      produces 'application/json'
+      consumes 'application/json'
+      parameter name: :accession_number, in: :query, type: :string, required: true
+      security [api_key: []]
+
+      let(:Authorization) { 'dummy' }
+      let(:accession_number) { '12345' }
+
+      response 200, 'Success' do
+        schema type: :object, properties: {
+          exists: { type: :boolean }
+        }
+
+        run_test! do |response|
+          response = JSON.parse(response.body)
+
+          expect(response['exists']).to be false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This can be tested on the following URL
```bash
host:port/api/v1/lab/accession_number?accession_number=1239081
```
The response object
```bash
{
  "exists": false
}
```
If the exists equals true then the accession number already exists. If it is false then you can proceed in creating the order.

Swagger Docs Will come later.

In order to test the GEM locally. Clone this project and also have the BHT-EMR-API project setup locally.

In the BHT-EMR-API Gemfile update the `gem 'his_emr_api_lab', '~> 1.1.24'` to
```bash
gem 'his_emr_api_lab', path: 'path to the his_emr_api_lab local repo'
```

Once updated do `bundle install`
This will now start pointing to the local library