### PR TITLE
handling result date from LIMS

### DIFF
--- a/app/services/lab/lims/pull_worker.rb
+++ b/app/services/lab/lims/pull_worker.rb
@@ -191,9 +191,11 @@ module Lab
           end
           
           next if test.result || test_results['results'].blank?
-
+          
+          result_date = Time.now
           measures = test_results['results'].map do |indicator, value|
             measure = find_measure(order, indicator, value)
+            result_date = value['result_date'] || result_date
             next nil unless measure
 
             measure
@@ -205,7 +207,7 @@ module Lab
           creator = format_result_entered_by(test_results['result_entered_by'])
 
           ResultsService.create_results(test.id,  { provider_id: User.current.person_id,
-                                                    date: Utils.parse_date(test_results['date_result_entered'], order[:order_date].to_s),
+                                                    date: Utils.parse_date(test_results['date_result_entered'], result_date),
                                                     comments: "LIMS import: Entered by: #{creator}",
                                                     measures: measures } )
         end


### PR DESCRIPTION
This fixes the issue where all results pushed electronically are the same time as the order date.

The expected response object from LIMS is as below
```bash
"results": {
            "Viral Load": {
                "Viral Load": "< LDL copies/ml",
                "result_date": "2023-04-28"
            }
        }
```