### PR TITLE
Configurable Lab Printouts

### DIFF
--- a/lib/auto12epl.rb
+++ b/lib/auto12epl.rb
@@ -133,9 +133,9 @@ class Auto12Epl
 
     # combine EPL statements
     if stat.nil?
-      "\nN\nR216,0\nZT\nS1\n#{name_element}\n#{pid_dob_age_gender_element}\n#{barcode_element}\n#{barcode_human_element}\n#{collector_element}\n#{tests_element}\nP3\n"
+      "\nN\nR216,0\nZT\nS1\n#{name_element}\n#{pid_dob_age_gender_element}\n#{barcode_element}\n#{barcode_human_element}\n#{collector_element}\n#{tests_element}\nP#{::GlobalPropertyService.print_copies}\n"
     else
-      "\nN\nR216,0\nZT\nS1\n#{name_element}\n#{pid_dob_age_gender_element}\n#{barcode_element}\n#{barcode_human_element}\n#{collector_element}\n#{tests_element}\n#{stat_element}\nP3\n"
+      "\nN\nR216,0\nZT\nS1\n#{name_element}\n#{pid_dob_age_gender_element}\n#{barcode_element}\n#{barcode_human_element}\n#{collector_element}\n#{tests_element}\n#{stat_element}\nP#{::GlobalPropertyService.print_copies}\n"
     end
   end
 

--- a/lib/auto12epl.rb
+++ b/lib/auto12epl.rb
@@ -133,9 +133,9 @@ class Auto12Epl
 
     # combine EPL statements
     if stat.nil?
-      "\nN\nR216,0\nZT\nS1\n#{name_element}\n#{pid_dob_age_gender_element}\n#{barcode_element}\n#{barcode_human_element}\n#{collector_element}\n#{tests_element}\nP#{::GlobalPropertyService.print_copies}\n"
+      "\nN\nR216,0\nZT\nS1\n#{name_element}\n#{pid_dob_age_gender_element}\n#{barcode_element}\n#{barcode_human_element}\n#{collector_element}\n#{tests_element}\nP#{print_copies}\n"
     else
-      "\nN\nR216,0\nZT\nS1\n#{name_element}\n#{pid_dob_age_gender_element}\n#{barcode_element}\n#{barcode_human_element}\n#{collector_element}\n#{tests_element}\n#{stat_element}\nP#{::GlobalPropertyService.print_copies}\n"
+      "\nN\nR216,0\nZT\nS1\n#{name_element}\n#{pid_dob_age_gender_element}\n#{barcode_element}\n#{barcode_human_element}\n#{collector_element}\n#{tests_element}\n#{stat_element}\nP#{print_copies}\n"
     end
   end
 
@@ -175,6 +175,12 @@ class Auto12Epl
   def generate_barcode_element(x, y, height, schema_track)
     schema_track = schema_track.gsub('-', '').strip
     "B#{x},#{y},#{BARCODE_ROTATION},#{BARCODE_TYPE},#{BARCODE_NARROW_WIDTH},#{BARCODE_WIDE_WIDTH},#{height},#{BARCODE_IS_HUMAN_READABLE},\"#{schema_track}\""
+  end
+
+  def print_copies
+    property = ::GlobalProperty.find_by(property: 'max.lab.order.print.copies')
+    value = property&.property_value&.strip
+    value || 3
   end
 end
 


### PR DESCRIPTION
## Context
We have request to make lab sticker printout configurable unlike just printing three all of the time. This PR makes this feature possible by using system properties.

## How to test the printing locally
You will need to change the Gemfile to point to this repo. comment out the his_emr_api_lab line and add this line to it

```ruby
gem 'his_emr_api_lab', git:  'https://github.com/EGPAFMalawiHIS/his_emr_api_lab.git', branch: 'chore/lab-printouts'
```

## Ticket
[Shortcut Issue Ticket](https://app.shortcut.com/egpaf-2/story/3304/11771-printing-of-excess-barcodes-in-emr-to-support-integration)