### PR TITLE
Replace observation time with date created for result serializer

### DIFF
--- a/app/serializers/lab/result_serializer.rb
+++ b/app/serializers/lab/result_serializer.rb
@@ -15,7 +15,7 @@ module Lab
             concept_id: concept_name&.concept_id,
             name: concept_name&.name
           },
-          date: measure.obs_datetime,
+          date: measure.date_created,
           value:,
           value_type:,
           value_modifier: measure.value_modifier


### PR DESCRIPTION
This PR fixes the issue of order date being the same as release date by replacing the ob_datetime with date_created for the result serializer.

Solves the HelpDesk #12067: [EID/VL order date same as result release](https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000020083025/details)  and also the order date and result date being the same on alerts 