### PR TITLE
Order Result Date

### DIFF
--- a/app/services/lab/lims/pull_worker.rb
+++ b/app/services/lab/lims/pull_worker.rb
@@ -232,7 +232,7 @@ module Lab
           creator = format_result_entered_by(test_results['result_entered_by'])
 
           ResultsService.create_results(test.id, { provider_id: User.current.person_id,
-                                                   date: Utils.parse_date(test_results['date_result_entered'],
+                                                   date: Utils.parse_date(test_results['result_date'] || result_date,
                                                                           order[:order_date].to_s),
                                                    comments: "LIMS import: Entered by: #{creator}",
                                                    measures: })


### PR DESCRIPTION
## Pull Request Description

### Summary
This pull request addresses an issue where the Order Result Date was incorrectly set to the Order Date, leading to discrepancies between the VL Reports and the Patient Order page.

### Problem
The discrepancy occurred because the result service was referencing an incorrect parameter in the Data Transfer Object (DTO), causing it to default to the Order Date.

### Solution
The result service has been updated to reference the correct parameter in the DTO to ensure the Order Result Date is accurately reflected. 

### Changes
- Modified the result service to use the correct DTO parameter for the Order Result Date.
- Verified that the VL Reports and Patient Order page now display consistent result dates.

### Testing
- Confirmed that the Order Result Date is correctly displayed in both the VL Reports and Patient Order page.
- Ensured no unintended side effects on other functionalities dependent on the result service.

### Impact
This fix ensures consistency in date reporting across different sections of the application, improving data accuracy and reducing user confusion.

### Ticket
[HELPHESK](https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000020083025/details)
[Shortcut](https://app.shortcut.com/egpaf-2/story/3718/helpdesk-12067-eid-vl-order-date-same-as-result-release-date)