### PR TITLE
Fix FBC HCT Indicator

### DIFF
--- a/app/services/lab/concepts_service.rb
+++ b/app/services/lab/concepts_service.rb
@@ -66,7 +66,7 @@ module Lab
                            .select(:concept_id)
 
       ConceptSet.where(concept_set: measures, concept_id: test)
-                .joins('INNER JOIN concept_name AS measure ON measure.concept_id = concept_set.concept_set')
+                .joins("INNER JOIN concept_name AS measure ON measure.concept_id = concept_set.concept_set AND (measure.locale_preferred = 1 OR measure.concept_name_type = 'SHORT' OR measure.concept_name_type = 'FULLY_SPECIFIED')")
                 .select('measure.concept_id, measure.name')
                 .group('measure.concept_id')
                 .map { |concept| { name: concept.name, concept_id: concept.concept_id } }

--- a/app/services/lab/lims/utils.rb
+++ b/app/services/lab/lims/utils.rb
@@ -24,10 +24,6 @@ module Lab
         'indian ink' => 'India ink'
       }.freeze
 
-      TEST_INDICATOR_MAPPINGS = {
-        'HCT' => 10_532
-      }.freeze
-
       def self.translate_test_name(test_name)
         TEST_NAME_MAPPINGS.fetch(test_name.downcase, test_name)
       end
@@ -83,11 +79,9 @@ module Lab
       end
 
       def self.find_concept_by_name(name)
-        concept_id = TEST_INDICATOR_MAPPINGS[name.upcase]
-        query_condition = concept_id.nil? ? { name: CGI.unescapeHTML(name) } : { concept_id: }
         ConceptName.joins(:concept)
-                   .merge(Concept.all)
-                   .where(query_condition)
+                   .merge(Concept.all) # Filter out voided
+                   .where(name: CGI.unescapeHTML(name))
                    .first
       end
     end


### PR DESCRIPTION
### Context
* The current implementation is pointing to an OPD Drug Concept.
* The current changes depend on the following
1.  EMR API Implements a migration of all the wrong FCB references
2. The EMR metadata is update

### Ticket
[Shortcut](https://app.shortcut.com/egpaf-2/story/3865/fbc-lab-results-showing-hydrochlorothiazide-instead-of-hct-in-the-iblis-the-information-is-correct)