### PR TITLE
Added functionality to check how many orders were drawn

### DIFF
--- a/app/controllers/lab/orders_controller.rb
+++ b/app/controllers/lab/orders_controller.rb
@@ -57,8 +57,8 @@ module Lab
     end
 
     def summary
-      start_date = params[:start_date].present? ? params[:start_date] : 24.hours.ago.beginning_of_hour
-      end_date = params[:end_date].present? ? params[:end_date].to_date.end_of_day : 24.hours.ago.end_of_hour
+      start_date = params[:start_date].present? ? params[:start_date] : 24.hours.ago.beginning_of_day
+      end_date = params[:end_date].present? ? params[:end_date].to_date.end_of_day : 24.hours.ago.end_of_day
       concept_id = params[:concept_id]
       include_data = params[:include_data]
       orders = OrdersService.lab_orders(start_date, end_date, concept_id, include_data: include_data)

--- a/app/controllers/lab/orders_controller.rb
+++ b/app/controllers/lab/orders_controller.rb
@@ -56,6 +56,15 @@ module Lab
       render json: { message: 'Results processed successfully' }, status: :ok
     end
 
+    def summary
+      start_date = params[:start_date].present? ? params[:start_date] : 24.hours.ago.beginning_of_hour
+      end_date = params[:end_date].present? ? params[:end_date].to_date.end_of_day : 24.hours.ago.end_of_hour
+      concept_id = params[:concept_id]
+      include_data = params[:include_data]
+      orders = OrdersService.lab_orders(start_date, end_date, concept_id, include_data: include_data)
+      render json: orders, status: :ok
+    end
+
     private
 
     def authenticate_request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Lab::Engine.routes.draw do
     collection do
       post :order_status
       post :order_result
+      get  :summary
     end
   end
   resources :tests, path: 'api/v1/lab/tests', except: %i[update] do # ?pending=true to select tests without results?


### PR DESCRIPTION
- Added functionality to check how many orders were done at a particular period of time. 
- End point:   GET /api/v1/lab/order/summary

Parameters include
1.  start_date - defaults to previous day start of day
2.  end_date - defaults to previous day end of day
3.  concept_id  - for filtering specific test
4. include_data - for whether to have a response with actual orders or only counts