### PR TITLE
Add visit_id to order response and update authentication skip behavior

### DIFF
--- a/app/controllers/lab/orders_controller.rb
+++ b/app/controllers/lab/orders_controller.rb
@@ -2,7 +2,7 @@
 
 module Lab
   class OrdersController < ApplicationController
-    skip_before_action :authenticate, only: %i[order_status order_result summary]
+    skip_before_action :authenticate, only: %i[order_status order_result summary], raise: false
     before_action :authenticate_request, only: %i[order_status order_result summary]
 
     def create

--- a/app/serializers/lab/lab_order_serializer.rb
+++ b/app/serializers/lab/lab_order_serializer.rb
@@ -18,6 +18,7 @@ module Lab
           order_type_id: order.order_type_id,
           order_id: order.order_id, # Deprecated: Link to :id
           encounter_id: order.encounter_id,
+          visit_id: encounter&.visit_id,
           order_date: order.start_date,
           location_id: encounter&.location_id,
           program_id: encounter&.program_id,

--- a/lib/lab/version.rb
+++ b/lib/lab/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lab
-  VERSION = '2.2.2'
+  VERSION = '2.2.3'
 end


### PR DESCRIPTION
Enhance the order response by including the visit_id and modify the authentication skip behavior to prevent raising exceptions. Additionally, bump the version to 2.2.3.