### PR TITLE
Fix acknowledgement worker to process all pending records in batch mode [A CASE OF NSANJE DHO - applicable to all sites]

### DIFF
--- a/app/services/lab/acknowledgement_service.rb
+++ b/app/services/lab/acknowledgement_service.rb
@@ -14,12 +14,11 @@ module Lab
                                         date_received: params[:date_received])
       end
 
-      def acknowledgements_pending_sync(batch_size, start_date: nil)
+      def acknowledgements_pending_sync(batch_size, start_date: nil, last_order_id: 0)
         query = Lab::LabAcknowledgement.joins(:order).where(pushed: false)
-
+                                       .where('lims_acknowledgement_statuses.order_id > ?', last_order_id)
         query = query.where('orders.date_created >= ?', start_date) if start_date
-
-        query.limit(batch_size)
+        query.order('lims_acknowledgement_statuses.order_id ASC').limit(batch_size)
       end
 
       def push_acknowledgement(acknowledgement, lims_api)

--- a/app/services/lab/lims/acknowledgement_worker.rb
+++ b/app/services/lab/lims/acknowledgement_worker.rb
@@ -28,7 +28,18 @@ module Lab
             logger.error("Failed to push acknowledgement ##{acknowledgement.order_id}: #{e.class} - #{e.message}")
           end
 
-          break unless wait
+          # If no records found or not waiting, check if we should continue
+          if acknowledgements.empty?
+            break unless wait
+          elsif !wait && acknowledgements.size < batch_size
+            # Processed final partial batch in one-shot mode
+            logger.info("Processed final batch of #{acknowledgements.size} acknowledgements")
+            break
+          elsif !wait
+            # More records likely exist, continue processing
+            logger.info('Batch complete, checking for more acknowledgements...')
+            next
+          end
 
           logger.info('Waiting for acknowledgements...')
           sleep(Lab::Lims::Config.updates_poll_frequency)

--- a/app/services/lab/lims/acknowledgement_worker.rb
+++ b/app/services/lab/lims/acknowledgement_worker.rb
@@ -16,14 +16,17 @@ module Lab
       end
 
       def push_acknowledgement(batch_size: 1000, wait: false)
+        last_order_id = 0
         loop do
           logger.info('Looking for new acknowledgements to push to LIMS...')
           acknowledgements = Lab::AcknowledgementService.acknowledgements_pending_sync(batch_size,
-                                                                                       start_date: start_date).all
+                                                                                       start_date: start_date,
+                                                                                       last_order_id: last_order_id).all
 
           logger.debug("Found #{acknowledgements.size} acknowledgements...")
           acknowledgements.each do |acknowledgement|
             Lab::AcknowledgementService.push_acknowledgement(acknowledgement, @lims_api)
+            last_order_id = acknowledgement.order_id
           rescue StandardError => e
             logger.error("Failed to push acknowledgement ##{acknowledgement.order_id}: #{e.class} - #{e.message}")
           end


### PR DESCRIPTION
**Fix acknowledgement worker to process all pending records in batch mode**

Fixed a critical bug in `Lab::Lims::AcknowledgementWorker#push_acknowledgement` where the worker would only process a single batch of 1,000 records and exit when called with `wait: false`, leaving large backlogs of pending acknowledgements unsynced. The worker now continues processing batches until all pending acknowledgements (where `pushed: false`) are successfully pushed to LIMS, only stopping when no more records are found or when processing a final partial batch smaller than the batch size. This ensures that environments with large backlogs (e.g., 200,000+ acknowledgements) can fully sync without requiring manual intervention or daemon mode (`wait: true`). The daemon mode behavior remains unchanged, continuing to poll indefinitely for new acknowledgements as before.