### PR TITLE
Handle accession number validation failure and improve error logging

### DIFF
--- a/app/controllers/lab/orders_controller.rb
+++ b/app/controllers/lab/orders_controller.rb
@@ -58,6 +58,10 @@ module Lab
     def verify_tracking_number
       tracking_number = params.require(:accession_number)
       render json: { exists: OrdersService.check_tracking_number(tracking_number) }, status: :ok
+    rescue Lab::Lims::ValidationUnavailable => e
+      # Return 502 Bad Gateway to indicate the external service is unavailable
+      # This allows the frontend to prompt user for confirmation
+      render json: { errors: [e.message] }, status: :bad_gateway
     end
 
     def destroy
@@ -74,7 +78,7 @@ module Lab
 
     def order_status
       order_params = params.permit(:tracking_number, :status, :status_time, :comments, :status_id,
-                                    updated_by: [:first_name, :last_name, :id, :phone_number])
+                                   updated_by: %i[first_name last_name id phone_number])
       OrdersService.update_order_status(order_params)
       render json: { message: "Status for order #{order_params['tracking_number']} successfully updated" }, status: :ok
     end

--- a/app/services/lab/lims/exceptions.rb
+++ b/app/services/lab/lims/exceptions.rb
@@ -8,17 +8,18 @@ module Lab
       class MissingAccessionNumber < LimsException; end
       class UnknownSpecimenType < LimsException; end
       class UnknownTestType < LimsException; end
+      class ValidationUnavailable < LimsException; end
     end
   end
 end
 
-
 module Lab
   module Lims
-      class LimsException < StandardError; end
-      class DuplicateNHID < LimsException; end
-      class MissingAccessionNumber < LimsException; end
-      class UnknownSpecimenType < LimsException; end
-      class UnknownTestType < LimsException; end
+    class LimsException < StandardError; end
+    class DuplicateNHID < LimsException; end
+    class MissingAccessionNumber < LimsException; end
+    class UnknownSpecimenType < LimsException; end
+    class UnknownTestType < LimsException; end
+    class ValidationUnavailable < LimsException; end
   end
 end

--- a/app/services/lab/orders_service.rb
+++ b/app/services/lab/orders_service.rb
@@ -56,8 +56,14 @@ module Lab
 
         Order.transaction do
           encounter = find_encounter(order_params)
-          if order_params[:accession_number].present? && check_tracking_number(order_params[:accession_number])
-            raise 'Accession number already exists'
+          if order_params[:accession_number].present?
+            begin
+              raise 'Accession number already exists' if check_tracking_number(order_params[:accession_number])
+            rescue Lab::Lims::ValidationUnavailable => e
+              # Log warning but allow order creation to proceed
+              # User should have been prompted to confirm on the frontend
+              Rails.logger.warn("Creating order with unvalidated accession number: #{e.message}")
+            end
           end
 
           order = create_order(encounter, order_params)
@@ -364,6 +370,15 @@ module Lab
         # fetch from the rest api and check if it exists
         lims_api = Lab::Lims::ApiFactory.create_api
         lims_api.verify_tracking_number(accession_number).present?
+      rescue StandardError => e
+        # Log the error for debugging
+        Rails.logger.error("Failed to verify accession number with NLIMS: #{e.message}")
+        Rails.logger.error(e.backtrace.join("\n"))
+
+        # Raise a specific exception indicating validation is unavailable
+        # This allows the controller to handle it differently than "accession exists"
+        raise Lab::Lims::ValidationUnavailable,
+              "Failed to communicate with external service: #{e.message}"
       end
 
       ##


### PR DESCRIPTION
Enhance the handling of accession number validation failures by introducing a specific exception for validation unavailability. Improve error logging to capture issues when verifying accession numbers with external services, allowing for better debugging and user prompts on the frontend.