### PR TITLE
Enhance notification creation to prevent duplicates

### DIFF
--- a/app/services/lab/notification_service.rb
+++ b/app/services/lab/notification_service.rb
@@ -27,22 +27,46 @@ class Lab::NotificationService
     end
   end
 
-  def create_notification(alert_type, alert_message)
+  def create_notification(alert_type, alert_message,
+                          uniq_checkers: { test_type_id: nil, order_id: nil, specimen_id: nil })
     return if alert_type != 'LIMS'
 
-    # Use unscoped to find user regardless of location context
-    lab = Lab::Lims::Utils.lab_user
+    test_type_id = uniq_checkers[:test_type_id]
+    order_id = uniq_checkers[:order_id]
+    specimen_id = uniq_checkers[:specimen_id]
 
+    return unless test_type_id.present? && order_id.present? && specimen_id.present?
+
+    lab = Lab::Lims::Utils.lab_user
     unless lab
       Rails.logger.warn('NotificationService: lab_daemon user not found, skipping notification creation')
       return
     end
 
     ActiveRecord::Base.transaction do
-      alert = NotificationAlert.create!(text: alert_message.to_json, date_to_expire: Time.now + not_period.days,
-                                        creator: lab, changed_by: lab, date_created: Time.now)
-      notify(alert, User.joins(:roles).uniq)
-      # ActionCable.server.broadcast('nlims_channel', alert)
+      # Atomic find or create - checks and creates in one operation
+      alert = NotificationAlert.find_or_create_by!(
+        test_type_id: test_type_id,
+        order_id: order_id,
+        specimen_id: specimen_id
+      ) do |new_alert|
+        # Only set these attributes on creation
+        new_alert.text = alert_message.to_json
+        new_alert.date_to_expire = Time.now + not_period.days
+        new_alert.creator = lab
+        new_alert.changed_by = lab
+        new_alert.date_created = Time.now
+      end
+
+      # Only notify if this is a new record (not a duplicate)
+      notify(alert, User.joins(:roles).uniq) if alert.previously_new_record?
+    rescue ActiveRecord::RecordNotUnique
+      # Handle race condition if unique constraint exists
+      Rails.logger.info("Duplicate notification prevented for test_type: #{test_type_id}, order: #{order_id}, specimen: #{specimen_id}")
+    rescue ActiveRecord::InvalidForeignKey => e
+      Rails.logger.error("Invalid foreign key: #{e.message}")
+    rescue StandardError => e
+      Rails.logger.error("Unexpected error: #{e.message}")
     end
   end
 

--- a/app/services/lab/results_service.rb
+++ b/app/services/lab/results_service.rb
@@ -74,6 +74,11 @@ module Lab
       def precess_notification_message(result, values, result_enter_by)
         order = Order.find(result.order_id)
         test_concept_id = result.test&.value_coded
+        uniq_checkers = {
+          test_type_id: test_concept_id,
+          order_id: order&.order_id,
+          specimen_id: order.concept_id
+        }
 
         data = { Type: result_enter_by,
                  Specimen: get_test_catalog_name(order.concept_id) || ConceptName.find_by(concept_id: order.concept_id)&.name,
@@ -84,7 +89,7 @@ module Lab
                  PatientID: result.person_id,
                  'Ordered By': Order.columns.include?('provider_id') ? order&.provider&.person&.name : Person.find(User.unscoped.find(order.creator).person_id)&.name,
                  Result: values }.as_json
-        NotificationService.new.create_notification(result_enter_by, data)
+        NotificationService.new.create_notification(result_enter_by, data, uniq_checkers: uniq_checkers)
       end
 
       def process_acknowledgement(results, results_enter_by)

--- a/lib/lab/version.rb
+++ b/lib/lab/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lab
-  VERSION = '2.3.8'
+  VERSION = '2.3.9.beta'
 end

--- a/lib/lab/version.rb
+++ b/lib/lab/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lab
-  VERSION = '2.3.9.beta'
+  VERSION = '2.4.0'
 end


### PR DESCRIPTION
Improve the `create_notification` method to prevent duplicate alerts by implementing a unique check mechanism. Enhance error handling for various exceptions during notification creation. Update the notification call in the processing method to utilize the new uniqueness checks.